### PR TITLE
Missing service definition in WcmRespositoryController

### DIFF
--- a/grails-app/controllers/org/weceem/controllers/WcmRepositoryController.groovy
+++ b/grails-app/controllers/org/weceem/controllers/WcmRepositoryController.groovy
@@ -48,6 +48,7 @@ class WcmRepositoryController {
     def wcmContentRepositoryService
 
     def grailsApplication
+	def proxyHandler
 
     def beforeInterceptor = {
         if (!(actionName in ACTIONS_NEEDING_SPACE)) return true


### PR DESCRIPTION
Added in "def proxyHandler" to WcmRepositoryController - with it missing, I was unable to search the repositories using the built in Weceem Search box.
