### PR TITLE
2 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target-eclipse
 .classpath
 .link_to_grails_plugins
 plugin.xml
+/bin/

--- a/WeceemGrailsPlugin.groovy
+++ b/WeceemGrailsPlugin.groovy
@@ -6,7 +6,7 @@ class WeceemGrailsPlugin {
     def _log = LogFactory.getLog('org.weceem.WeceemGrailsPlugin')
 
     // the plugin version
-    def version = "1.5-SNAPSHOT"
+    def version = "1.6-SNAPSHOT"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.3 > *"
 

--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,5 @@
 #Grails Metadata file
 #Tue May 14 13:45:47 CEST 2013
-app.grails.version=2.4.4
+app.grails.version=2.4.5
 app.name=weceem
-app.version=1.5-SNAPSHOT
+app.version=1.6-SNAPSHOT

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -34,9 +34,13 @@ grails.project.dependency.resolution = {
 	plugins {
         // plugins for the build system only
         build   ':tomcat:7.0.55'
-        runtime(':hibernate4:4.3.6.1') {
+		runtime (":hibernate:3.6.10.17"){
             export = false
         }
+		
+//        runtime(':hibernate4:4.3.6.1') {
+//            export = false
+//        }
         runtime ':database-migration:1.4.0'
         runtime ':elasticsearch:0.0.3.6'
 

--- a/grails-app/controllers/org/weceem/controllers/WcmRepositoryController.groovy
+++ b/grails-app/controllers/org/weceem/controllers/WcmRepositoryController.groovy
@@ -121,7 +121,7 @@ class WcmRepositoryController {
                 haveChildren.put(domainClass.name, wcmContentRepositoryService.triggerDomainEvent(dcInst, WeceemDomainEvents.contentShouldAcceptChildren))
             }
             return [content:nodes, contentTypes:wcmContentRepositoryService.listContentClassNames(), 
-                'haveChildren':haveChildren, space: params.space, spaces: WcmSpace.listOrderByName() ]
+                'haveChildren':haveChildren, space: params.space, spaces: WcmSpace.listOrderByName(), adminPrefix:grailsApplication.config.weceem.admin.prefix ]
         } else {
             flash.message = 'message.there.are.no.spaces'
             redirect(controller:'wcmSpace')

--- a/grails-app/taglib/org/weceem/tags/WidgetTagLib.groovy
+++ b/grails-app/taglib/org/weceem/tags/WidgetTagLib.groovy
@@ -42,7 +42,7 @@ class WidgetTagLib {
     def widget = {attrs, body ->
         def widget
         def path = attrs.path
-        def space = attrs.space ? WcmSpace.findByAliasURI(attrs.space) : request[RenderEngine.REQUEST_ATTRIBUTE_SPACE]
+        def space = (attrs.space!=null) ? WcmSpace.findByAliasURI(attrs.space) : request[RenderEngine.REQUEST_ATTRIBUTE_SPACE]
         if(!space) {throwTagError("No space by name ${attrs.space} or in page scope")}
 
         if (path) {

--- a/grails-app/views/wcmRepository/treeTable.gsp
+++ b/grails-app/views/wcmRepository/treeTable.gsp
@@ -140,6 +140,7 @@ $(function(){
 <div id="createNewDialog" class="ui-helper-hidden" title="${message(code:'content.title.create', encodeAs:"HTML")}">
     <g:form controller="wcmEditor" action="create" method="GET">
         <input id="requestPath" name="requestPath" type="hidden" value="${request.contextPath}"/>
+        <input id="adminPath" name="adminPath" type="hidden" value="${request.contextPath}/${adminPrefix}"/>
         <input id="parentid" name="parent.id" type="hidden"/>
         <div id="parentInformation" style="display: inline;">
             <b>${message(code:'content.label.parentContent', encodeAs:"HTML")}:</b>&nbsp;

--- a/web-app/_weceem/js/treeTable/javascripts/core.treeTable.js
+++ b/web-app/_weceem/js/treeTable/javascripts/core.treeTable.js
@@ -628,8 +628,9 @@ function initTreeTable() {
                 // check if the parent accept child
                 var childType = $("#createNewType").val()
                 var requestPath = $("#requestPath").attr("value")
+                var adminPath = $("#adminPath").attr("value")
                 $.ajax({
-                    url: requestPath+"/admin/repository/canAcceptChild?parentid="+parentid+"&childtype="+childType,
+                    url: adminPath+"/repository/canAcceptChild?parentid="+parentid+"&childtype="+childType,
                     success:function(data) {
                         $("#parentid").attr("value", parentid)
                         if (data && data.result) {


### PR DESCRIPTION
In these commits there are 2 fixes, among some ground noise:

1.) allow empty space names in WidgetTagLib.groovy

2.) non-hardcoded admin url in core.treeTable.js
in core.treeTable.js, treeTable.gsp and WcmRepositoryController.groovy.

Please ignore the rest. Sorry for the crappy pull request with all the unneccessary file changes. I just hate git, and I don't want to learn how to use it. What a time waster.