### PR TITLE
Added a name to ehcache being used.

### DIFF
--- a/src/java/weceem-default-ehcache.xml
+++ b/src/java/weceem-default-ehcache.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="ehcache.xsd"
+         xsi:noNamespaceSchemaLocation="ehcache.xsd" name="weceemCache"
              updateCheck="true" monitoring="autodetect">
 
     <defaultCache


### PR DESCRIPTION
I've encountered issues while combining some libraries with the ehcache name. Basically EhCache stopped allowing multiple unnamed caches to exist. Causing a problem when another library is also having an unnamed ehcache going.

This is to make all of that go away, or at least to make the problem everyone else's except weceems!