### PR TITLE
Fix XSS vulnerability in the Grails Fields plugin.

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -44,7 +44,7 @@ grails.project.dependency.resolution = {
         compile ':scaffolding:2.1.2'
         compile ':cache:1.1.8'
         compile ':cache-headers:1.1.7'
-        compile ':fields:1.4'
+        compile ':fields:1.6'
         compile ':ckeditor:4.4.1.0'
         compile ':feeds:1.6'
 


### PR DESCRIPTION
Versions prior to 1.6 of the Fields plugin are open to stored XSS
atacks. This commit upgrades the dependency in question.

See https://github.com/martinfrancois/CVE-2018-1000529 for more details
and a demo app illustrating the issue.